### PR TITLE
Add lightweight ESP32 modem control console

### DIFF
--- a/ESP32-simple-modem/ESP32-simple-modem.ino
+++ b/ESP32-simple-modem/ESP32-simple-modem.ino
@@ -1,0 +1,212 @@
+#include <Arduino.h>
+
+#include "SimpleLoRaModem.h"
+
+// Update the pin mapping to match your ESP32 + LoRa module wiring.
+constexpr LoRaPins LORA_PINS = {
+    .ss = 18,
+    .rst = 14,
+    .dio0 = 26,
+    .sck = 5,
+    .miso = 19,
+    .mosi = 27,
+};
+
+constexpr uint32_t DEFAULT_FREQUENCY_HZ = 868100000UL;
+constexpr uint8_t DEFAULT_SPREADING_FACTOR = 7;  // SF7
+constexpr uint16_t DEFAULT_BANDWIDTH_KHZ = 125;  // 125 kHz
+constexpr uint8_t DEFAULT_CODING_RATE = 5;       // 4/5
+constexpr int8_t DEFAULT_TX_POWER_DBM = 14;      // 14 dBm
+
+SimpleLoRaModem modem(LORA_PINS);
+
+String readCommand();
+void handleCommand(const String &command);
+void printHelp();
+void printStatus();
+void applyDefaults(bool force = false);
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) {
+        delay(10);
+    }
+
+    Serial.println(F("Simple ESP32 LoRa modem control console"));
+    Serial.println(F("----------------------------------------"));
+
+    applyDefaults();
+    printHelp();
+}
+
+void loop() {
+    String command = readCommand();
+    if (command.length() > 0) {
+        handleCommand(command);
+    }
+}
+
+String readCommand() {
+    if (!Serial.available()) {
+        return String();
+    }
+
+    String line = Serial.readStringUntil('\n');
+    line.trim();
+    return line;
+}
+
+void handleCommand(const String &command) {
+    if (command.isEmpty()) {
+        return;
+    }
+
+    int spaceIndex = command.indexOf(' ');
+    String verb = (spaceIndex == -1) ? command : command.substring(0, spaceIndex);
+    String arg = (spaceIndex == -1) ? String() : command.substring(spaceIndex + 1);
+    verb.toLowerCase();
+    arg.trim();
+
+    if (verb == F("help")) {
+        printHelp();
+        return;
+    }
+
+    if (verb == F("status")) {
+        printStatus();
+        return;
+    }
+
+    if (verb == F("freq")) {
+        double value = arg.toDouble();
+        if (value <= 0.0) {
+            Serial.println(F("Usage: freq <MHz or Hz>"));
+            return;
+        }
+        uint32_t hz = value < 1000.0 ? static_cast<uint32_t>(value * 1e6) : static_cast<uint32_t>(value);
+        modem.setFrequency(hz);
+        double displayMHz = (value < 1000.0) ? value : hz / 1e6.0;
+        Serial.print(F("Frequency set to "));
+        Serial.print(displayMHz, 3);
+        Serial.println(F(" MHz"));
+        return;
+    }
+
+    if (verb == F("sf")) {
+        int sf = arg.toInt();
+        if (sf < 6 || sf > 12) {
+            Serial.println(F("Usage: sf <6-12>"));
+            return;
+        }
+        modem.setSpreadingFactor(static_cast<uint8_t>(sf));
+        Serial.print(F("Spreading factor set to SF"));
+        Serial.println(sf);
+        return;
+    }
+
+    if (verb == F("bw")) {
+        int bw = arg.toInt();
+        if (bw != 125 && bw != 250 && bw != 500) {
+            Serial.println(F("Usage: bw <125|250|500>"));
+            return;
+        }
+        modem.setBandwidth(static_cast<uint16_t>(bw));
+        Serial.print(F("Bandwidth set to "));
+        Serial.print(bw);
+        Serial.println(F(" kHz"));
+        return;
+    }
+
+    if (verb == F("cr")) {
+        int cr = arg.toInt();
+        if (cr < 5 || cr > 8) {
+            Serial.println(F("Usage: cr <5-8> (meaning coding rate 4/x)"));
+            return;
+        }
+        modem.setCodingRate(static_cast<uint8_t>(cr));
+        Serial.print(F("Coding rate set to 4/"));
+        Serial.println(cr);
+        return;
+    }
+
+    if (verb == F("txp")) {
+        int level = arg.toInt();
+        if (level < 2 || level > 17) {
+            Serial.println(F("Usage: txp <2-17> (dBm)"));
+            return;
+        }
+        modem.setTxPower(static_cast<int8_t>(level));
+        Serial.print(F("TX power set to "));
+        Serial.print(level);
+        Serial.println(F(" dBm"));
+        return;
+    }
+
+    if (verb == F("dump")) {
+        int start = 0;
+        int end = 0x70;
+        if (!arg.isEmpty()) {
+            int comma = arg.indexOf(' ');
+            if (comma == -1) {
+                start = strtol(arg.c_str(), nullptr, 0);
+                end = start + 0x10;
+            } else {
+                String startStr = arg.substring(0, comma);
+                String endStr = arg.substring(comma + 1);
+                start = strtol(startStr.c_str(), nullptr, 0);
+                end = strtol(endStr.c_str(), nullptr, 0);
+            }
+        }
+        start = constrain(start, 0, 0x7F);
+        end = constrain(end, 0, 0x7F);
+        modem.dumpRegisters(Serial, static_cast<uint8_t>(start), static_cast<uint8_t>(end));
+        return;
+    }
+
+    if (verb == F("reset")) {
+        applyDefaults(true);
+        Serial.println(F("Modem reinitialised with default parameters."));
+        return;
+    }
+
+    Serial.println(F("Unknown command. Type 'help' for a list of commands."));
+}
+
+void printHelp() {
+    Serial.println();
+    Serial.println(F("Available commands:"));
+    Serial.println(F("  help           - Show this message"));
+    Serial.println(F("  status         - Print current modem settings"));
+    Serial.println(F("  freq <value>   - Set frequency (MHz or Hz)"));
+    Serial.println(F("  sf <6-12>      - Set spreading factor"));
+    Serial.println(F("  bw <125|250|500>- Set bandwidth in kHz"));
+    Serial.println(F("  cr <5-8>       - Set coding rate (4/x)"));
+    Serial.println(F("  txp <2-17>     - Set TX power in dBm"));
+    Serial.println(F("  dump [start end]- Dump registers (optional range)"));
+    Serial.println(F("  reset          - Reapply default settings"));
+    Serial.println();
+}
+
+void printStatus() {
+    modem.dumpStatus(Serial);
+}
+
+void applyDefaults(bool force) {
+    if (force || !modem.ready()) {
+        if (!modem.begin(DEFAULT_FREQUENCY_HZ,
+                         DEFAULT_SPREADING_FACTOR,
+                         DEFAULT_BANDWIDTH_KHZ,
+                         DEFAULT_CODING_RATE,
+                         DEFAULT_TX_POWER_DBM)) {
+            Serial.println(F("Failed to initialise LoRa modem. Check wiring."));
+            return;
+        }
+    }
+
+    modem.setFrequency(DEFAULT_FREQUENCY_HZ);
+    modem.setSpreadingFactor(DEFAULT_SPREADING_FACTOR);
+    modem.setBandwidth(DEFAULT_BANDWIDTH_KHZ);
+    modem.setCodingRate(DEFAULT_CODING_RATE);
+    modem.setTxPower(DEFAULT_TX_POWER_DBM);
+    printStatus();
+}

--- a/ESP32-simple-modem/SimpleLoRaModem.cpp
+++ b/ESP32-simple-modem/SimpleLoRaModem.cpp
@@ -1,0 +1,224 @@
+#include "SimpleLoRaModem.h"
+
+namespace {
+constexpr uint32_t RADIO_XTAL_HZ = 32000000UL;
+
+uint8_t bandwidthCode(uint16_t bandwidthKHz) {
+    switch (bandwidthKHz) {
+        case 125: return 0x70; // BW 125 kHz
+        case 250: return 0x80; // BW 250 kHz
+        case 500: return 0x90; // BW 500 kHz
+        default: return 0xFF;
+    }
+}
+
+} // namespace
+
+SimpleLoRaModem::SimpleLoRaModem(const LoRaPins &pins) : pins_(pins) {}
+
+bool SimpleLoRaModem::begin(uint32_t frequencyHz,
+                            uint8_t spreadingFactor,
+                            uint16_t bandwidthKHz,
+                            uint8_t codingRate,
+                            int8_t txPowerDbm) {
+    ready_ = false;
+
+    pinMode(pins_.ss, OUTPUT);
+    digitalWrite(pins_.ss, HIGH);
+
+    if (pins_.rst >= 0) {
+        pinMode(pins_.rst, OUTPUT);
+    }
+    if (pins_.dio0 >= 0) {
+        pinMode(pins_.dio0, INPUT);
+    }
+
+    SPI.begin(pins_.sck, pins_.miso, pins_.mosi, pins_.ss);
+
+    resetChip();
+
+    sleep();
+    writeRegister(REG_OP_MODE, MODE_LONG_RANGE_MODE | MODE_SLEEP);
+    standby();
+
+    if (readRegister(REG_VERSION) != 0x12) {
+        return false;
+    }
+
+    writeRegister(REG_FIFO_TX_BASE_ADDR, 0x80);
+    writeRegister(REG_FIFO_RX_BASE_ADDR, 0x00);
+    writeRegister(REG_LNA, readRegister(REG_LNA) | 0x03);
+    writeRegister(REG_MODEM_CONFIG3, 0x04); // LNA gain set by the AGC loop
+
+    setFrequency(frequencyHz);
+    setBandwidth(bandwidthKHz);
+    setCodingRate(codingRate);
+    setSpreadingFactor(spreadingFactor);
+    setTxPower(txPowerDbm);
+
+    writeRegister(REG_SYNC_WORD, 0x34); // LoRaWAN public network sync word
+    writeRegister(REG_PREAMBLE_MSB, 0x00);
+    writeRegister(REG_PREAMBLE_LSB, 0x08);
+    writeRegister(REG_PAYLOAD_LENGTH, 0x00);
+    writeRegister(REG_SYMB_TIMEOUT_LSB, 0x64);
+
+    ready_ = true;
+    return true;
+}
+
+void SimpleLoRaModem::setFrequency(uint32_t frequencyHz) {
+    standby();
+    frequencyHz_ = frequencyHz;
+
+    uint64_t frf = ((uint64_t)frequencyHz << 19) / RADIO_XTAL_HZ;
+    writeRegister(REG_FRF_MSB, (uint8_t)(frf >> 16));
+    writeRegister(REG_FRF_MID, (uint8_t)(frf >> 8));
+    writeRegister(REG_FRF_LSB, (uint8_t)(frf));
+}
+
+void SimpleLoRaModem::setSpreadingFactor(uint8_t spreadingFactor) {
+    standby();
+    spreadingFactor_ = constrain(spreadingFactor, (uint8_t)6, (uint8_t)12);
+
+    if (spreadingFactor_ == 6) {
+        writeRegister(REG_DETECTION_OPTIMIZE, 0xC5);
+        writeRegister(REG_DETECTION_THRESHOLD, 0x0C);
+    } else {
+        writeRegister(REG_DETECTION_OPTIMIZE, 0xC3);
+        writeRegister(REG_DETECTION_THRESHOLD, 0x0A);
+    }
+
+    uint8_t config2 = readRegister(REG_MODEM_CONFIG2);
+    config2 = (config2 & 0x0F) | ((spreadingFactor_ << 4) & 0xF0);
+    writeRegister(REG_MODEM_CONFIG2, config2);
+
+    applyLowDataRateOpt();
+}
+
+void SimpleLoRaModem::setBandwidth(uint16_t bandwidthKHz) {
+    uint8_t code = bandwidthCode(bandwidthKHz);
+    if (code == 0xFF) {
+        return;
+    }
+
+    standby();
+    bandwidthKHz_ = bandwidthKHz;
+    uint8_t config1 = readRegister(REG_MODEM_CONFIG1);
+    config1 = (config1 & 0x0F) | code;
+    writeRegister(REG_MODEM_CONFIG1, config1);
+
+    applyLowDataRateOpt();
+}
+
+void SimpleLoRaModem::setCodingRate(uint8_t codingRate) {
+    standby();
+    codingRate_ = constrain(codingRate, (uint8_t)5, (uint8_t)8);
+    uint8_t cr = (codingRate_ - 4) & 0x07;
+    uint8_t config1 = readRegister(REG_MODEM_CONFIG1);
+    config1 = (config1 & 0xF1) | (cr << 1);
+    writeRegister(REG_MODEM_CONFIG1, config1);
+}
+
+void SimpleLoRaModem::setTxPower(int8_t txPowerDbm) {
+    standby();
+    txPowerDbm_ = constrain(txPowerDbm, (int8_t)2, (int8_t)17);
+    writeRegister(REG_PA_CONFIG, 0x80 | (txPowerDbm_ - 2));
+}
+
+void SimpleLoRaModem::dumpStatus(Stream &out) {
+    out.println(F("LoRa modem status:"));
+    out.print(F("  Ready: "));
+    out.println(ready_ ? F("yes") : F("no"));
+    out.print(F("  Frequency: "));
+    out.print(static_cast<double>(frequencyHz_) / 1e6, 3);
+    out.println(F(" MHz"));
+    out.print(F("  Spreading factor: SF"));
+    out.println(spreadingFactor_);
+    out.print(F("  Bandwidth: "));
+    out.print(bandwidthKHz_);
+    out.println(F(" kHz"));
+    out.print(F("  Coding rate: 4/"));
+    out.println(codingRate_);
+    out.print(F("  TX power: "));
+    out.print(txPowerDbm_);
+    out.println(F(" dBm"));
+}
+
+void SimpleLoRaModem::dumpRegisters(Stream &out, uint8_t start, uint8_t end) {
+    if (start > end) {
+        uint8_t tmp = start;
+        start = end;
+        end = tmp;
+    }
+
+    for (uint8_t addr = start; addr <= end; ++addr) {
+        if ((addr - start) % 8 == 0) {
+            out.println();
+            out.print(F("0x"));
+            if (addr < 16) {
+                out.print('0');
+            }
+            out.print(addr, HEX);
+            out.print(F(": "));
+        }
+        uint8_t value = readRegister(addr);
+        if (value < 16) {
+            out.print('0');
+        }
+        out.print(value, HEX);
+        out.print(' ');
+    }
+    out.println();
+}
+
+void SimpleLoRaModem::resetChip() {
+    if (pins_.rst < 0) {
+        return;
+    }
+
+    digitalWrite(pins_.rst, LOW);
+    delay(10);
+    digitalWrite(pins_.rst, HIGH);
+    delay(10);
+}
+
+void SimpleLoRaModem::applyLowDataRateOpt() {
+    uint8_t config3 = readRegister(REG_MODEM_CONFIG3);
+    if (spreadingFactor_ >= 11 && bandwidthKHz_ <= 125) {
+        config3 |= 0x08;
+    } else {
+        config3 &= ~0x08;
+    }
+    writeRegister(REG_MODEM_CONFIG3, config3 | 0x04); // ensure AGC is enabled
+}
+
+void SimpleLoRaModem::standby() {
+    setOpMode(MODE_STDBY);
+}
+
+void SimpleLoRaModem::sleep() {
+    setOpMode(MODE_SLEEP);
+}
+
+void SimpleLoRaModem::setOpMode(uint8_t mode) {
+    writeRegister(REG_OP_MODE, MODE_LONG_RANGE_MODE | mode);
+}
+
+uint8_t SimpleLoRaModem::readRegister(uint8_t addr) {
+    SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
+    digitalWrite(pins_.ss, LOW);
+    SPI.transfer(addr & 0x7F);
+    uint8_t value = SPI.transfer(0x00);
+    digitalWrite(pins_.ss, HIGH);
+    SPI.endTransaction();
+    return value;
+}
+
+void SimpleLoRaModem::writeRegister(uint8_t addr, uint8_t value) {
+    SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
+    digitalWrite(pins_.ss, LOW);
+    SPI.transfer(addr | 0x80);
+    SPI.transfer(value);
+    digitalWrite(pins_.ss, HIGH);
+    SPI.endTransaction();
+}

--- a/ESP32-simple-modem/SimpleLoRaModem.h
+++ b/ESP32-simple-modem/SimpleLoRaModem.h
@@ -1,0 +1,87 @@
+#ifndef SIMPLE_LORA_MODEM_H
+#define SIMPLE_LORA_MODEM_H
+
+#include <Arduino.h>
+#include <SPI.h>
+
+struct LoRaPins {
+    int8_t ss;
+    int8_t rst;
+    int8_t dio0;
+    int8_t sck;
+    int8_t miso;
+    int8_t mosi;
+};
+
+class SimpleLoRaModem {
+  public:
+    explicit SimpleLoRaModem(const LoRaPins &pins);
+
+    bool begin(uint32_t frequencyHz,
+               uint8_t spreadingFactor,
+               uint16_t bandwidthKHz,
+               uint8_t codingRate,
+               int8_t txPowerDbm);
+
+    void setFrequency(uint32_t frequencyHz);
+    void setSpreadingFactor(uint8_t spreadingFactor);
+    void setBandwidth(uint16_t bandwidthKHz);
+    void setCodingRate(uint8_t codingRate);
+    void setTxPower(int8_t txPowerDbm);
+
+    uint32_t frequency() const { return frequencyHz_; }
+    uint8_t spreadingFactor() const { return spreadingFactor_; }
+    uint16_t bandwidth() const { return bandwidthKHz_; }
+    uint8_t codingRate() const { return codingRate_; }
+    int8_t txPower() const { return txPowerDbm_; }
+    bool ready() const { return ready_; }
+
+    void dumpStatus(Stream &out);
+    void dumpRegisters(Stream &out, uint8_t start = 0x00, uint8_t end = 0x70);
+
+  private:
+    static constexpr uint8_t REG_FIFO = 0x00;
+    static constexpr uint8_t REG_OP_MODE = 0x01;
+    static constexpr uint8_t REG_FRF_MSB = 0x06;
+    static constexpr uint8_t REG_FRF_MID = 0x07;
+    static constexpr uint8_t REG_FRF_LSB = 0x08;
+    static constexpr uint8_t REG_PA_CONFIG = 0x09;
+    static constexpr uint8_t REG_LNA = 0x0C;
+    static constexpr uint8_t REG_FIFO_ADDR_PTR = 0x0D;
+    static constexpr uint8_t REG_FIFO_TX_BASE_ADDR = 0x0E;
+    static constexpr uint8_t REG_FIFO_RX_BASE_ADDR = 0x0F;
+    static constexpr uint8_t REG_MODEM_CONFIG1 = 0x1D;
+    static constexpr uint8_t REG_MODEM_CONFIG2 = 0x1E;
+    static constexpr uint8_t REG_SYMB_TIMEOUT_LSB = 0x1F;
+    static constexpr uint8_t REG_PREAMBLE_MSB = 0x20;
+    static constexpr uint8_t REG_PREAMBLE_LSB = 0x21;
+    static constexpr uint8_t REG_PAYLOAD_LENGTH = 0x22;
+    static constexpr uint8_t REG_MODEM_CONFIG3 = 0x26;
+    static constexpr uint8_t REG_DETECTION_OPTIMIZE = 0x31;
+    static constexpr uint8_t REG_DETECTION_THRESHOLD = 0x37;
+    static constexpr uint8_t REG_SYNC_WORD = 0x39;
+    static constexpr uint8_t REG_DIO_MAPPING_1 = 0x40;
+    static constexpr uint8_t REG_VERSION = 0x42;
+
+    static constexpr uint8_t MODE_LONG_RANGE_MODE = 0x80;
+    static constexpr uint8_t MODE_SLEEP = 0x00;
+    static constexpr uint8_t MODE_STDBY = 0x01;
+
+    LoRaPins pins_{};
+    uint32_t frequencyHz_ = 0;
+    uint16_t bandwidthKHz_ = 0;
+    uint8_t spreadingFactor_ = 0;
+    uint8_t codingRate_ = 0;
+    int8_t txPowerDbm_ = 0;
+    bool ready_ = false;
+
+    void resetChip();
+    void applyLowDataRateOpt();
+    void standby();
+    void sleep();
+    void setOpMode(uint8_t mode);
+    uint8_t readRegister(uint8_t addr);
+    void writeRegister(uint8_t addr, uint8_t value);
+};
+
+#endif // SIMPLE_LORA_MODEM_H

--- a/README.md
+++ b/README.md
@@ -26,13 +26,25 @@ on this code.
 I did find however that good soldering joints and wiring makes all the difference,
 so if you get resets you cannot explain, please have a second look at your wiring.
 
-This repository contains a proof-of-concept implementation of a single channel LoRaWAN gateway for the ESP8266. 
+This repository contains a proof-of-concept implementation of a single channel LoRaWAN gateway for the ESP8266.
 Starting version 5.2 also the ESP32 of TTGO (and others) is supported.
 The software implements a standard LoRa gateway with the following exceptions and changes:
 
--  This LoRa gateway is not a full gateway but it implements just a one-channel/one frequency gateway. 
+## ESP32 modem control console
+
+If you just need a lightweight way to drive an SX1276/78 based modem from an ESP32 without connecting to TTN,
+take a look at the `ESP32-simple-modem` sketch that is included with this repository. The sketch exposes a
+serial console that lets you configure the radio (frequency, spreading factor, bandwidth, coding rate and transmit
+power) and inspect register values without enabling the full single channel gateway stack. This is useful when you
+only want to validate the wiring of a LoRa module or integrate it with your own firmware.
+
+To get started open `ESP32-simple-modem/ESP32-simple-modem.ino` in the Arduino IDE, update the pin mapping at the
+top of the sketch so it matches your ESP32 board, upload it, and then use the serial monitor to send commands such
+as `status`, `freq 915.0`, `sf 9`, `bw 500`, or `dump 0x1d 0x26`.
+
+-  This LoRa gateway is not a full gateway but it implements just a one-channel/one frequency gateway.
 The minimum amount of frequencies supported by a full gateway is 3, most support 9 or more frequencies.
-This software started as a proof-of-concept to prove that a single low-cost RRFM95 chip which was present 
+This software started as a proof-of-concept to prove that a single low-cost RRFM95 chip which was present
 in almost every LoRa node in Europe could be used as a cheap alternative to the far more expensive full 
 gateways that were making use of the SX1301 chip.
 


### PR DESCRIPTION
## Summary
- add a new ESP32-simple-modem sketch that exposes a serial console for configuring an SX1276-based radio without the full gateway stack
- implement a SimpleLoRaModem helper to manage frequency, spreading factor, bandwidth, coding rate, transmit power and register inspection
- document the new sketch in the README for quick discovery and setup guidance

## Testing
- not run (Arduino sketch)


------
https://chatgpt.com/codex/tasks/task_e_68de18628db4832e8a696a3df17eab0a